### PR TITLE
Add webapp proxy to URL for POST request and fix parsing of table hea…

### DIFF
--- a/eupathtables/eupathtables.py
+++ b/eupathtables/eupathtables.py
@@ -179,7 +179,7 @@ class WebServiceIterator(object):
         out = []
         for line in s:
             if i == 0:
-                headers = re.findall('\[([^[]+)\]', line)
+                headers = line.split('\t')
                 i = i + 1
             else:
                 res = {}
@@ -222,7 +222,7 @@ class WebServiceIterator(object):
             }
         }
 
-        r = s.post(self.baseurl + "/service/answer/report",
+        r = s.post(self.baseurl + "/a/service/answer/report",
                    data=json.dumps(query_payload),
                    headers={'Content-Type': 'application/json'})
         r.raise_for_status()
@@ -450,7 +450,6 @@ if _gt_available:
 
                     # track UniProtID -> gene mappings
                     if 'uniprot_id' in v and v['uniprot_id'] is not None:
-                        logger.info(v)
                         for u in v['uniprot_id'].split(','):
                             if len(u) > 0:
                                 self.uniprots[u] = v['ID']


### PR DESCRIPTION
Hi Sascha,

A couple of updates to keep up with changes to EuPathDB web services.  Just to let you know, we are expecting to release some major architecture changes that will impact web services sometime next year so this will probably need a more substantial re-write then.

Changes here:

- Web services queries using the POST method now require the part of the URL that defines the webapp.  We have a proxy for this which works for all sites, so I have used the proxy as the webapp name is not consistent between projects (e.g., plasmo for PlasmoDB, fungidb for FungiDB)

- The format of the header row in the data that comes back from the POST query has changed.  It used to be that each column was in square brackets - now the brackets have gone and it is tab delimited.  This means that the test to see if there is a header will always be true unless no data comes back at all - given the impending changes, I didn't bother to change the test as it seems to be working for now.

Hope you are well!

K