### PR TITLE
Fix filenames for organisms with slash in strain id and capitalisatio…

### DIFF
--- a/eupathtables/fileset.py
+++ b/eupathtables/fileset.py
@@ -99,12 +99,12 @@ def create_fileset_for_organism(baseurl, organism, login):
             fn = laststream.next_tree()
 
     # write out GFF for organism
-    with open('%s.gff3' % organism, 'w') as fd:
+    with open('%s.gff3' % organism.replace('/', '_'), 'w') as fd:
         fd.write("{0}".format(f.getvalue().decode('utf-8')))
 
     # download FASTA for organism
     sp = SequenceProvider(baseurl, organism, login=login)
-    sp.to_file("%s.fasta" % organism)
+    sp.to_file("%s.fasta" % organism.replace('/', '_'))
 
     # write out GAF for organism
-    table_in_stream.go_coll.to_gafv1(open('%s.gaf' % organism, "w+"))
+    table_in_stream.go_coll.to_gafv1(open('%s.gaf' % organism.replace('/', '_'), "w+"))

--- a/eupathtables/sequenceaccess.py
+++ b/eupathtables/sequenceaccess.py
@@ -51,6 +51,7 @@ class SequenceProvider(object):
         self.baseurl = "%s://%s" % (parsed_url.scheme, parsed_url.netloc)
         project_id = parsed_url.netloc.split('.')[0].capitalize()
         project_id = re.sub('db$', 'DB', project_id)
+        project_id = project_id.replace('Tritryp', 'TriTryp')
         payload = {'project_id': project_id,
                    'ids': '\n'.join(seqids)}
         url = ('{0}/cgi-bin/contigSrt').format(self.baseurl)


### PR DESCRIPTION
…n in TriTrypDB

Two minor fixes:

1. Some organisms in TriTryp have strain names that contain "/".  This was creating problems when writing files.  Substituted "/" for "_" in output file names

2. The POST payload for fasta sequence retrieval was failing in TriTrypDB because the project identifier was incorrectly capitalised.  Fixed.